### PR TITLE
Service testing

### DIFF
--- a/Weightlifting/WEB.Tests/Services/AccountServiceTests.cs
+++ b/Weightlifting/WEB.Tests/Services/AccountServiceTests.cs
@@ -1,0 +1,55 @@
+﻿using Xunit;
+using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using System.Net.Http;
+using WEB.Services;
+using System.Net.Http.Json;
+using WEB.ViewModels.Athletes;
+using System.Threading.Tasks;
+
+namespace WEB.Tests.Services
+{ 
+    public class AccountServiceTests
+    {
+        private readonly HttpClient _httpClient;
+        private readonly HttpMessageHandler mock_handler;
+        private readonly AccountService _sut;
+
+        public AccountServiceTests()
+        {
+            mock_handler = Substitute.For<HttpMessageHandler>();
+            _httpClient = new HttpClient(mock_handler);
+
+            _sut = new AccountService(_httpClient);
+        }
+
+        //[Fact]
+        public async void RegisterAthlete_WhenPassedInvalidRegistrationDetails_ReturnsFailureMessage()
+        {
+            // Arrange
+            string expected = "Registration failed";
+
+            RegisterAthlete input = new RegisterAthlete()
+            {
+                FirstName = "Fail",
+                Email = "Bad email",
+                Password = "Bad password"
+            };
+
+            HttpResponseMessage response = new HttpResponseMessage()
+            {
+                Content = new StringContent("test content"),
+                StatusCode = System.Net.HttpStatusCode.BadRequest
+            };
+
+            _httpClient.PostAsJsonAsync("Api url", Substitute.For<RegisterAthlete>())
+                .Returns(Task.FromResult(response));
+
+            // Act
+            var actual = await _sut.RegisterAthlete(input);
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/Weightlifting/WEB.Tests/Services/AccountServiceTests.cs
+++ b/Weightlifting/WEB.Tests/Services/AccountServiceTests.cs
@@ -1,52 +1,71 @@
 ﻿using Xunit;
+
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
+
+using System.Net;
+using System.Threading;
+using System;
 using System.Net.Http;
+
 using WEB.Services;
-using System.Net.Http.Json;
 using WEB.ViewModels.Athletes;
-using System.Threading.Tasks;
+using WEB.Tests.Utility;
+
 
 namespace WEB.Tests.Services
 { 
     public class AccountServiceTests
     {
-        private readonly HttpClient _httpClient;
-        private readonly HttpMessageHandler mock_handler;
-        private readonly AccountService _sut;
+        private HttpClient _httpClient;
+        private AccountService _sut;
 
         public AccountServiceTests()
         {
-            mock_handler = Substitute.For<HttpMessageHandler>();
-            _httpClient = new HttpClient(mock_handler);
-
-            _sut = new AccountService(_httpClient);
+            
         }
 
-        //[Fact]
+        [Fact]
         public async void RegisterAthlete_WhenPassedInvalidRegistrationDetails_ReturnsFailureMessage()
         {
             // Arrange
             string expected = "Registration failed";
 
-            RegisterAthlete input = new RegisterAthlete()
-            {
-                FirstName = "Fail",
-                Email = "Bad email",
-                Password = "Bad password"
-            };
+            var mockHttpMessageHandler = Substitute.ForPartsOf<MockHttpMessageHandler>();
+            var httpClient = new HttpClient(mockHttpMessageHandler) { BaseAddress = new Uri("https://localhost:7207/") };
 
-            HttpResponseMessage response = new HttpResponseMessage()
-            {
-                Content = new StringContent("test content"),
-                StatusCode = System.Net.HttpStatusCode.BadRequest
-            };
+            var mockResponse = new HttpResponseMessage(HttpStatusCode.BadRequest);
 
-            _httpClient.PostAsJsonAsync("Api url", Substitute.For<RegisterAthlete>())
-                .Returns(Task.FromResult(response));
+            mockHttpMessageHandler.MockSend(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
+               .Returns(mockResponse);
+
+            _sut = new AccountService(httpClient);
 
             // Act
-            var actual = await _sut.RegisterAthlete(input);
+            var actual = await _sut.RegisterAthlete(Substitute.For<RegisterAthlete>());
+
+            // Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public async void RegisterAthlete_WhenPassedValidRegistrationDetails_ReturnsSuccessMessage()
+        {
+            // Arrange
+            string expected = "Registration success!";
+
+            var mockHttpMessageHandler = Substitute.ForPartsOf<MockHttpMessageHandler>();
+            var httpClient = new HttpClient(mockHttpMessageHandler) { BaseAddress = new Uri("https://localhost:7207/") };
+
+            var mockResponse = new HttpResponseMessage(HttpStatusCode.OK);
+
+            mockHttpMessageHandler.MockSend(Arg.Any<HttpRequestMessage>(), Arg.Any<CancellationToken>())
+               .Returns(mockResponse);
+
+            _sut = new AccountService(httpClient);
+
+            // Act
+            var actual = await _sut.RegisterAthlete(Substitute.For<RegisterAthlete>());
 
             // Assert
             Assert.Equal(expected, actual);

--- a/Weightlifting/WEB.Tests/Utility/MockHttpMessageHandler.cs
+++ b/Weightlifting/WEB.Tests/Utility/MockHttpMessageHandler.cs
@@ -1,0 +1,27 @@
+﻿
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace WEB.Tests.Utility
+{
+    public class MockHttpMessageHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(MockSend(request, cancellationToken));
+        }
+
+        protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return MockSend(request, cancellationToken);
+        }
+
+        public virtual HttpResponseMessage MockSend(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Weightlifting/WEB.Tests/WEB.Tests.csproj
+++ b/Weightlifting/WEB.Tests/WEB.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NSubstitute" Version="5.0.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\API\API.csproj" />
+    <ProjectReference Include="..\WEB\WEB.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Weightlifting/WEB/Services/AccountService.cs
+++ b/Weightlifting/WEB/Services/AccountService.cs
@@ -16,7 +16,7 @@ namespace WEB.Services
         {
             var result = await _httpClient.GetFromJsonAsync<HttpResponse>("api/account/check");
 
-            if (result.StatusCode == 401)
+            if (result is not null && result.StatusCode == 401)
             {
                 return "failed to access";
             }

--- a/Weightlifting/Weightlifting.sln
+++ b/Weightlifting/Weightlifting.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "API.Tests", "API.Tests\API.
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WEB", "WEB\WEB.csproj", "{3BAB6EA9-FC53-4E8C-9E3A-A3E7C21858B8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WEB.Tests", "WEB.Tests\WEB.Tests.csproj", "{8B552A9D-A916-4BC1-8949-068029E9EDEE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{3BAB6EA9-FC53-4E8C-9E3A-A3E7C21858B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3BAB6EA9-FC53-4E8C-9E3A-A3E7C21858B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3BAB6EA9-FC53-4E8C-9E3A-A3E7C21858B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8B552A9D-A916-4BC1-8949-068029E9EDEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8B552A9D-A916-4BC1-8949-068029E9EDEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8B552A9D-A916-4BC1-8949-068029E9EDEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8B552A9D-A916-4BC1-8949-068029E9EDEE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Have sorted testing for services relying on HttpClient calls to the API. 

HttpClient is used in the AccountService class to execute calls to the API. In order to mock this class's behaviour to isolate the AccountService's behaviour, we need an interface (IHttpClient) or for it to have virtual methods (overrideable). It has neither! 

So we have to use a concrete HttpClient, and mock the HttpMessageHandler, which is injected and actually does the leg work. This has protected internal virtual and abstract methods for Send and SendAsync. We can extend this class in MockHttpMessageHandler, override those methods, and then Substitute return values in the test. 

So then we need to initialise HttpClient for each test, injecting a MockHttpMessageHandler with the appropriate return value to test the service. 

It's a bit fiddly, but it's working now. 